### PR TITLE
ci: python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        # 3.6 will reach EoL in December 2021
-        # https://devguide.python.org/#status-of-python-branches
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        # 3.9 will reach EoL in October 2025
+        # https://devguide.python.org/versions/
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     steps:
       - uses: actions/checkout@v2
       - name: Setup python


### PR DESCRIPTION
update the ci test step to use the currently supported python versions 

update the link to the python version page 